### PR TITLE
Allow empty meta for failing responses.

### DIFF
--- a/gemini.lisp
+++ b/gemini.lisp
@@ -45,7 +45,7 @@
     (error 'malformed-response :reason "response is longer than 1024 bytes"))
   (setf res (string-trim '(#\return #\newline) res))
   (destructuring-bind (status &optional meta) (cl-ppcre:split "\\s+" res :limit 2)
-    (unless meta
+    (when (and (< (parse-integer status) 40) (not meta))
       (error 'malformed-response :reason "missing meta"))
     (list (parse-status status) meta)))
 


### PR DESCRIPTION
I've tested `gemini:request` on "gemini://gemini.conman.org/test/torture/", and it returned 52 with no meta. Gemini spec (https://gemini.circumlunar.space/docs/specification.gmi, parts 3.2.4 to 3.2.6) says that "\<META\> _may_ provide" information on failure. There can be no meta for failing responses, it seems :)