### PR TITLE
Support binary request body.

### DIFF
--- a/gemini.lisp
+++ b/gemini.lisp
@@ -85,7 +85,7 @@ response is fetched, then return the meta and the (decoded) body."
       (format ssl-stream "~a~c~c" req #\return #\newline)
       (force-output ssl-stream)
       (let ((resp (parse-response (read-until ssl-stream #\newline))))
-        (values resp (if (and (= (first resp) 20)
+        (values resp (if (and (eq (first resp) :success)
                               (second resp)
                               (string= (subseq (second resp) 0 5) "text/"))
                          (read-all-string ssl-stream)

--- a/gemini.lisp
+++ b/gemini.lisp
@@ -61,8 +61,11 @@
   (let ((data (make-array 0 :element-type '(unsigned-byte 8) :adjustable t :fill-pointer 0)))
     (loop with buffer = (make-array 1024 :element-type '(unsigned-byte 8))
           for n-bytes = (read-sequence buffer in)
+          for data-size = (array-dimension data 0)
           while (< 0 n-bytes)
-          do (serapeum:vector-conc-extend data buffer n-bytes))
+          do (adjust-array data (+ data-size n-bytes))
+          do (incf (fill-pointer data) n-bytes)
+          do (replace data buffer :start1 data-size :end2 n-bytes))
     data))
 
 (defun read-until (in char)

--- a/gemini.lisp
+++ b/gemini.lisp
@@ -49,13 +49,21 @@
       (error 'malformed-response :reason "missing meta"))
     (list (parse-status status) meta)))
 
-(defun read-all-stream (in)
+(defun read-all-string (in)
   (with-output-to-string (out)
     (loop with buffer = (make-array 1024 :element-type 'character)
           for n-chars = (read-sequence buffer in)
           while (< 0 n-chars)
           do (write-sequence buffer out :start 0
                                         :end n-chars))))
+
+(defun read-all-bytes (in)
+  (let ((data (make-array 0 :element-type '(unsigned-byte 8) :adjustable t :fill-pointer 0)))
+    (loop with buffer = (make-array 1024 :element-type '(unsigned-byte 8))
+          for n-bytes = (read-sequence buffer in)
+          while (< 0 n-bytes)
+          do (serapeum:vector-conc-extend data buffer n-bytes))
+    data))
 
 (defun read-until (in char)
   (with-output-to-string (out)
@@ -77,7 +85,11 @@ response is fetched, then return the meta and the (decoded) body."
       (format ssl-stream "~a~c~c" req #\return #\newline)
       (force-output ssl-stream)
       (let ((resp (parse-response (read-until ssl-stream #\newline))))
-        (values resp (read-all-stream ssl-stream))))))
+        (values resp (if (and (= (first resp) 20)
+                              (second resp)
+                              (string= (subseq (second resp) 0 4) "text"))
+                         (read-all-string ssl-stream)
+                         (read-all-bytes ssl-stream)))))))
 
 (defgeneric request (url)
   (:documentation "Perform a request for the URL"))

--- a/gemini.lisp
+++ b/gemini.lisp
@@ -87,7 +87,7 @@ response is fetched, then return the meta and the (decoded) body."
       (let ((resp (parse-response (read-until ssl-stream #\newline))))
         (values resp (if (and (= (first resp) 20)
                               (second resp)
-                              (string= (subseq (second resp) 0 4) "text"))
+                              (string= (subseq (second resp) 0 5) "text/"))
                          (read-all-string ssl-stream)
                          (read-all-bytes ssl-stream)))))))
 


### PR DESCRIPTION
@omar-polo, hi again! I noticed that `phos` implies textual UTF-8 data as the only payload type. However, a lot of data is actually binary. We needed to address that at some moment, and here's the patch for it. `phos/gemini:request` simply returns an `(unsigned-byte 8)` array if the data is not `text/*`.

This also includes the `read-all-stream` to `read-all-string` renaming, as it's not the only stream-draining function now.

Thanks for the `read-sequence` hack, by the way! I didn't know one can do such a convenient buffered input in CL :D 

Does this look sane?

P.S. Having response status to be a list and a first return value of the `request` is somewhat inconvenient. How about doing `(values data numeric-status meta)` instead, so that one can simply call the function and work with data directly, without `(nth-value 1 ...)`? If you're fine with this, I can open a PR :)