### PR TITLE
Remove cl-mime dependency.

### DIFF
--- a/phos.asd
+++ b/phos.asd
@@ -6,7 +6,7 @@
   :license "ISC"
   :version "0.0.1"
   :serial t
-  :depends-on ("quri" "cl-ppcre" "trivia" "usocket" "cl+ssl" "cl-mime")
+  :depends-on ("quri" "cl-ppcre" "trivia" "usocket" "cl+ssl")
   :components ((:file "package")
                (:file "phos")
                (:file "gemtext")


### PR DESCRIPTION
`cl-mime` doesn't seem to be used anywhere in `phos` code, while making dependency footprint larger (using `phos` in Nyxt requires us to depend on the otherwise unnecessary `cl-qprint`, for example).

@omar-polo, did you plan to use it sometime in the future? Can something more popular and lightweight (like [Shinmera's `trivial-mimes`](https://github.com/Shinmera/trivial-mimes)) work there? 

Beware: I'm obviously lobbying Nyxt side here, not wanting to propagate unnecessary dependencies there (while `trivial-mimes` are already a dependency of Nyxt).